### PR TITLE
Commented out the Survival System Icons on Player HUD.

### DIFF
--- a/client/systems/hud/playerHud.sqf
+++ b/client/systems/hud/playerHud.sqf
@@ -85,7 +85,7 @@ _displayTerritoryActivity =
 	[_topLeftIconText, _activityMessage]
 };
 
-_survivalSystem = ["A3W_survivalSystem"] call isConfigOn;
+//_survivalSystem = ["A3W_survivalSystem"] call isConfigOn;
 _unlimitedStamina = ["A3W_unlimitedStamina"] call isConfigOn;
 _atmEnabled = ["A3W_atmEnabled"] call isConfigOn;
 
@@ -140,10 +140,10 @@ while {true} do
 
 	_strArray pushBack format ["%1 <img size='0.7' image='client\icons\money.paa'/>", [player getVariable ["cmoney", 0]] call fn_numbersText];
 
-	if (_survivalSystem) then {
-		_strArray pushBack format ["%1 <img size='0.7' image='client\icons\water.paa'/>", ceil (thirstLevel max 0)];
-		_strArray pushBack format ["%1 <img size='0.7' image='client\icons\food.paa'/>", ceil (hungerLevel max 0)];
-	};
+	//if (_survivalSystem) then {
+	//	_strArray pushBack format ["%1 <img size='0.7' image='client\icons\water.paa'/>", ceil (thirstLevel max 0)];
+	//	_strArray pushBack format ["%1 <img size='0.7' image='client\icons\food.paa'/>", ceil (hungerLevel max 0)];
+	//};
 
 	if (!_unlimitedStamina) then {
 		_strArray pushBack format ["%1 <img size='0.7' image='client\icons\running_man.paa'/>", 100 - ceil ((getFatigue player) * 100)];


### PR DESCRIPTION
I located the playerhud.sqf file and located the references to the Food and Water icons. I commented them out.